### PR TITLE
Support plurals

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@
 
 ## What?
 
-TextRef is an abstraction over Android strings. It's a wrapper around a String or string resource ID.
-With the help of a `Context` a final string can be resolved. Format args are supported too!
+TextRef is an abstraction over Android text. It wraps a `String` or a string/plurals resource ID.
+With the help of an Android `Context` a final `String` can be resolved. Format args are supported too!
 
 ## How?
 
 **Create**
 ```kotlin
-TextRef("My string")
-TextRef(R.string.my_string)
-TextRef("The arguments are %d and %s", 5, "foo")
-TextRef(R.string.the_arguments_are, 5, "foo")
+TextRef.string("My string")
+TextRef.stringRes(R.string.my_string)
+TextRef.pluralsRes(R.plurals.number_of_items, 3)
+TextRef.string("The arguments are %d and %s", 5, "foo")
 ```
 
 **Resolve**
@@ -26,7 +26,7 @@ val text: String = textRef.resolve(context)
 
 ## Why?
 
-* **String agnostic APIs:** Make functions return TextRefs to allow for both strings and string resource IDs
+* **String agnostic APIs:** Make functions return TextRefs to allow for any type of text representation
 * **Less dependent on Context:** No need to resolve string resources close to business logic such as view models
 * **Lazy formatting:** Pass format args and let TextRef do the formatting as late as possible.
 * **Simplified testing:** No need to mock `Context.getString`
@@ -43,9 +43,9 @@ fun renderUserName(text: TextRef) {
 
 // Presenter
 val userName = if (user != null) {
-    TextRef(user.name)
+    TextRef.string(user.name)
 } else {
-    TextRef(R.string.guest)
+    TextRef.stringRes(R.string.guest)
 }
 view.renderUserName(userName)
 ```

--- a/lib/src/androidTest/java/com/ioki/textref/TextRefParcelableTest.kt
+++ b/lib/src/androidTest/java/com/ioki/textref/TextRefParcelableTest.kt
@@ -12,31 +12,43 @@ class TextRefParcelableTest {
         private val argsList = listOf(
             emptyArray(),
             arrayOf(1, "foo", true, 5L, 3.3, listOf("foo", "bar"), mapOf(1 to "foo", 2 to "bar"), List::class.java),
-            arrayOf(TextRef("foo", TextRef("bar")))
+            arrayOf(TextRef.string("foo", TextRef.string("bar")))
         )
     }
 
     @Test
     fun parcelStringRes() {
         argsList.forEach { args ->
-            assertThatObjectParcelable(TextRef(1, *args))
+            assertThatObjectParcelable(TextRef.stringRes(1, *args))
+        }
+    }
+
+    @Test
+    fun parcelPluralsRes() {
+        argsList.forEach { args ->
+            assertThatObjectParcelable(TextRef.pluralsRes(1, 5, *args))
         }
     }
 
     @Test
     fun parcelString() {
         argsList.forEach { args ->
-            assertThatObjectParcelable(TextRef("foobar", *args))
+            assertThatObjectParcelable(TextRef.string("foobar", *args))
         }
     }
 
     @Test(expected = RuntimeException::class)
     fun parcelStringResWithNonParcelable() {
-        assertThatObjectParcelable(TextRef(1, Unit))
+        assertThatObjectParcelable(TextRef.stringRes(1, Unit))
     }
 
     @Test(expected = RuntimeException::class)
     fun parcelStringWithNonParcelable() {
-        assertThatObjectParcelable(TextRef("foobar", Unit))
+        assertThatObjectParcelable(TextRef.string("foobar", Unit))
+    }
+
+    @Test(expected = RuntimeException::class)
+    fun parcelPluralsResWithNonParcelable() {
+        assertThatObjectParcelable(TextRef.pluralsRes(1, 5, Unit))
     }
 }

--- a/lib/src/main/java/com/ioki/textref/TextRef.kt
+++ b/lib/src/main/java/com/ioki/textref/TextRef.kt
@@ -25,7 +25,10 @@ private constructor(
      * @param string The string used to create the TextRef
      * @param args Format args used to format the string
      */
-    @Deprecated("Use factory function instead", ReplaceWith("TextRef.string(string, *args)"))
+    @Deprecated(
+        "Use factory function instead",
+        ReplaceWith("TextRef.string(string, *args)", "com.ioki.textref.TextRef")
+    )
     constructor(string: String, vararg args: Any) : this(string as Any, *args)
 
     /**
@@ -34,7 +37,10 @@ private constructor(
      * @param id The String resource ID used to create the TextRef
      * @param args Format args used to format the string
      */
-    @Deprecated("Use factory function instead", ReplaceWith("TextRef.stringRes(id, *args)"))
+    @Deprecated(
+        "Use factory function instead",
+        ReplaceWith("TextRef.stringRes(id, *args)", "com.ioki.textref.TextRef")
+    )
     constructor(@StringRes id: Int, vararg args: Any) : this(id as Any, *args)
 
     /**

--- a/lib/src/main/java/com/ioki/textref/TextRef.kt
+++ b/lib/src/main/java/com/ioki/textref/TextRef.kt
@@ -4,8 +4,9 @@ import android.content.Context
 import android.os.Parcel
 import android.os.ParcelFormatException
 import android.os.Parcelable
+import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
-import java.util.Arrays
+import java.util.*
 
 /**
  * An abstraction of text that holds either a [String] object or a [StringRes] ID.
@@ -24,6 +25,7 @@ private constructor(
      * @param string The string used to create the TextRef
      * @param args Format args used to format the string
      */
+    @Deprecated("Use factory function instead", ReplaceWith("TextRef.string(string, *args)"))
     constructor(string: String, vararg args: Any) : this(string as Any, *args)
 
     /**
@@ -32,6 +34,7 @@ private constructor(
      * @param id The String resource ID used to create the TextRef
      * @param args Format args used to format the string
      */
+    @Deprecated("Use factory function instead", ReplaceWith("TextRef.stringRes(id, *args)"))
     constructor(@StringRes id: Int, vararg args: Any) : this(id as Any, *args)
 
     /**
@@ -47,8 +50,19 @@ private constructor(
         return when {
             value is String && args.isEmpty() -> value
             value is String -> value.format(*args)
-            args.isEmpty() -> context.getString(value as Int)
-            else -> context.getString(value as Int, *args)
+            value is Int && args.isEmpty() -> context.getString(value)
+            value is Int -> context.getString(value, *args)
+            value is Pair<*, *> && args.isEmpty() -> {
+                val id = value.first as Int
+                val quantity = value.second as Int
+                context.resources.getQuantityString(id, quantity)
+            }
+            value is Pair<*, *> -> {
+                val id = value.first as Int
+                val quantity = value.second as Int
+                context.resources.getQuantityString(id, quantity, *args)
+            }
+            else -> error("Unsupported type: ${value.javaClass.name}")
         }
     }
 
@@ -72,14 +86,16 @@ private constructor(
 
     override fun hashCode(): Int {
         var result = value.hashCode()
-        result = 31 * result + Arrays.hashCode(args)
+        result = 31 * result + args.contentHashCode()
         return result
     }
 
     override fun toString(): String {
         val textString = when (value) {
             is String -> "string=$value"
-            else -> "id=$value"
+            is Int -> "id=$value"
+            is Pair<*, *> -> "id=${value.first}, quantity=${value.second}"
+            else -> error("Unsupported type: ${value.javaClass.name}")
         }
         val argString = if (args.isEmpty())
             ""
@@ -98,6 +114,11 @@ private constructor(
                 parcel.writeInt(TYPE_STRING)
                 parcel.writeString(value)
             }
+            is Pair<*, *> -> {
+                parcel.writeInt(TYPE_PLURALS_RES)
+                parcel.writeInt(value.first as Int)
+                parcel.writeInt(value.second as Int)
+            }
             else -> throw ParcelFormatException("Unsupported type class: ${value::class.java} for value: $value")
         }
         parcel.writeArray(args)
@@ -110,20 +131,58 @@ private constructor(
          * A TextRef holding an empty [String]
          */
         @JvmField
-        val EMPTY = TextRef("")
+        val EMPTY = TextRef("" as Any)
+
+        /**
+         * Creates a new TextRef from a [String]. Supports formatting using [java.util.Formatter].
+         *
+         * @param string The string used to create the TextRef
+         * @param args Format args used to format the string
+         */
+        fun string(string: String, vararg args: Any): TextRef {
+            return TextRef(string as Any, *args)
+        }
+
+        /**
+         * Creates a new TextRef from an Android [StringRes] ID. Supports formatting using [java.util.Formatter].
+         *
+         * @param id The String resource ID used to create the TextRef
+         * @param args Format args used to format the string
+         */
+        fun stringRes(@StringRes id: Int, vararg args: Any): TextRef {
+            return TextRef(id as Any, *args)
+        }
+
+        /**
+         * Creates a new TextRef from an Android [PluralsRes] ID. Supports formatting using [java.util.Formatter].
+         *
+         * @param id The String resource ID used to create the TextRef
+         * @param quantity The quantity to use for plural resolution
+         * @param args Format args used to format the string
+         */
+        fun pluralsRes(@PluralsRes id: Int, quantity: Int, vararg args: Any): TextRef {
+            return TextRef((id to quantity), *args)
+        }
 
         override fun createFromParcel(parcel: Parcel): TextRef {
+            val classLoader = this::class.java.classLoader
             val type = parcel.readInt()
             return when (type) {
                 TYPE_STRING_RES -> {
-                    val resId = parcel.readInt()
-                    val args = parcel.readArray(this::class.java.classLoader)!!
-                    TextRef(resId, *args)
+                    val id = parcel.readInt()
+                    val args = parcel.readArray(classLoader)!!
+                    TextRef.stringRes(id, *args)
                 }
                 TYPE_STRING -> {
                     val string = parcel.readString()!!
-                    val args = parcel.readArray(this::class.java.classLoader)!!
-                    TextRef(string, *args)
+                    val args = parcel.readArray(classLoader)!!
+                    TextRef.string(string, *args)
+                }
+                TYPE_PLURALS_RES -> {
+                    val id = parcel.readInt()
+                    val quantity = parcel.readInt()
+                    val args = parcel.readArray(classLoader)!!
+                    TextRef.pluralsRes(id, quantity, *args)
                 }
                 else -> throw ParcelFormatException("Unsupported type id: $type")
             }
@@ -135,5 +194,6 @@ private constructor(
 
         private const val TYPE_STRING_RES = 1
         private const val TYPE_STRING = 2
+        private const val TYPE_PLURALS_RES = 3
     }
 }

--- a/lib/src/test/java/com/ioki/textref/TextRefTest.kt
+++ b/lib/src/test/java/com/ioki/textref/TextRefTest.kt
@@ -1,6 +1,7 @@
 package com.ioki.textref
 
 import android.content.Context
+import android.content.res.Resources
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -15,6 +16,11 @@ class TextRefTest {
     @Mock
     private lateinit var mockContext: Context
 
+    @Mock
+    private lateinit var mockResources: Resources
+
+    private val quantity = 7
+
     private val stringWithoutArg = "foo"
     private val stringWithIntArg = "foo %d"
     private val stringWithStringArg = "foo %s"
@@ -27,7 +33,7 @@ class TextRefTest {
 
     private val intArg = 5
     private val stringArg = "bar"
-    private val textRefArg = TextRef(stringArg)
+    private val textRefArg = TextRef.string(stringArg)
 
     private val formattedStringWithIntArg = "foo $intArg"
     private val formattedStringWithStringArg = "foo bar"
@@ -38,108 +44,171 @@ class TextRefTest {
     private val formattedIdWithStringArg = "biz bar"
     private val formattedIdWithTwoArgs = "biz $intArg bar"
 
+    private val formattedPluralWithoutArg = "boz"
+    private val formattedPluralWithIntArg = "boz $intArg"
+    private val formattedPluralWithStringArg = "boz bar"
+    private val formattedPluralWithTwoArgs = "boz $intArg bar"
+
     @Before
     fun setUp() {
+        `when`(mockContext.resources).thenReturn(mockResources)
         `when`(mockContext.getString(idWithoutArg)).thenReturn(formattedIdWithoutArg)
         `when`(mockContext.getString(idWithIntArg, intArg)).thenReturn(formattedIdWithIntArg)
         `when`(mockContext.getString(idWithStringArg, stringArg)).thenReturn(formattedIdWithStringArg)
         `when`(mockContext.getString(idWithTwoArgs, intArg, stringArg)).thenReturn(formattedIdWithTwoArgs)
+        `when`(mockResources.getQuantityString(idWithoutArg, quantity)).thenReturn(formattedPluralWithoutArg)
+        `when`(mockResources.getQuantityString(idWithIntArg, quantity, intArg)).thenReturn(formattedPluralWithIntArg)
+        `when`(mockResources.getQuantityString(idWithStringArg, quantity, stringArg)).thenReturn(
+            formattedPluralWithStringArg
+        )
+        `when`(mockResources.getQuantityString(idWithTwoArgs, quantity, intArg, stringArg)).thenReturn(
+            formattedPluralWithTwoArgs
+        )
     }
 
     @Test
     fun resolve_createdWithString_resultIsCorrect() {
-        val result = TextRef(stringWithoutArg).resolve(mockContext)
+        val result = TextRef.string(stringWithoutArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(stringWithoutArg)
     }
 
     @Test
-    fun resolve_createdWithId_resultIsCorrect() {
-        val result = TextRef(idWithoutArg).resolve(mockContext)
+    fun resolve_createdWithStringRes_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithoutArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedIdWithoutArg)
     }
 
     @Test
+    fun resolve_createdWithPluralsRes_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithoutArg, quantity).resolve(mockContext)
+
+        assertThat(result).isEqualTo(formattedPluralWithoutArg)
+    }
+
+    @Test
     fun resolve_createdWithStringAndIntArg_resultIsCorrect() {
-        val result = TextRef(stringWithIntArg, intArg).resolve(mockContext)
+        val result = TextRef.string(stringWithIntArg, intArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedStringWithIntArg)
     }
 
     @Test
     fun resolve_createdWithStringAndStringArg_resultIsCorrect() {
-        val result = TextRef(stringWithStringArg, stringArg).resolve(mockContext)
+        val result = TextRef.string(stringWithStringArg, stringArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedStringWithStringArg)
     }
 
     @Test
     fun resolve_createdWithStringAndTextRefArg_resultIsCorrect() {
-        val result = TextRef(stringWithStringArg, textRefArg).resolve(mockContext)
+        val result = TextRef.string(stringWithStringArg, textRefArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedStringWithStringArg)
     }
 
     @Test
     fun resolve_createdWithStringAndTwoArgs_resultIsCorrect() {
-        val result = TextRef(stringWithTwoArgs, intArg, stringArg).resolve(mockContext)
+        val result = TextRef.string(stringWithTwoArgs, intArg, stringArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedStringWithTwoArgs)
     }
 
     @Test
-    fun resolve_createdWithIdAndIntArg_resultIsCorrect() {
-        val result = TextRef(idWithIntArg, intArg).resolve(mockContext)
+    fun resolve_createdWithStringResAndIntArg_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithIntArg, intArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedIdWithIntArg)
     }
 
     @Test
-    fun resolve_createdWithIdAndStringArg_resultIsCorrect() {
-        val result = TextRef(idWithStringArg, stringArg).resolve(mockContext)
+    fun resolve_createdWithStringResAndStringArg_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithStringArg, stringArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedIdWithStringArg)
     }
 
     @Test
-    fun resolve_createdWithIdAndTextRefArg_resultIsCorrect() {
-        val result = TextRef(idWithStringArg, textRefArg).resolve(mockContext)
+    fun resolve_createdWithStringResAndTextRefArg_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithStringArg, textRefArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedIdWithStringArg)
     }
 
     @Test
-    fun resolve_createdWithIdAndTwoArgs_resultIsCorrect() {
-        val result = TextRef(idWithTwoArgs, intArg, stringArg).resolve(mockContext)
+    fun resolve_createdWithStringResAndTwoArgs_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithTwoArgs, intArg, stringArg).resolve(mockContext)
 
         assertThat(result).isEqualTo(formattedIdWithTwoArgs)
     }
 
     @Test
-    fun toString_createdWithId_resultIsCorrect() {
-        val result = TextRef(idWithoutArg).toString()
+    fun toString_createdWithStringRes_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithoutArg).toString()
 
         assertThat(result).isEqualTo("id=$idWithoutArg")
     }
 
     @Test
-    fun toString_createdWithIdAndTwoArgs_resultIsCorrect() {
-        val result = TextRef(idWithTwoArgs, intArg, stringArg).toString()
+    fun toString_createdWithStringResAndTwoArgs_resultIsCorrect() {
+        val result = TextRef.stringRes(idWithTwoArgs, intArg, stringArg).toString()
 
         assertThat(result).isEqualTo("id=$idWithTwoArgs, args=[$intArg, $stringArg]")
     }
 
     @Test
+    fun resolve_createdWithPluralResAndIntArg_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithIntArg, quantity, intArg).resolve(mockContext)
+
+        assertThat(result).isEqualTo(formattedPluralWithIntArg)
+    }
+
+    @Test
+    fun resolve_createdWithPluralResAndStringArg_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithStringArg, quantity, stringArg).resolve(mockContext)
+
+        assertThat(result).isEqualTo(formattedPluralWithStringArg)
+    }
+
+    @Test
+    fun resolve_createdWithPluralResAndTextRefArg_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithStringArg, quantity, textRefArg).resolve(mockContext)
+
+        assertThat(result).isEqualTo(formattedPluralWithStringArg)
+    }
+
+    @Test
+    fun resolve_createdWithPluralResAndTwoArgs_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithTwoArgs, quantity, intArg, stringArg).resolve(mockContext)
+
+        assertThat(result).isEqualTo(formattedPluralWithTwoArgs)
+    }
+
+    @Test
+    fun toString_createdWithPluralRes_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithoutArg, quantity).toString()
+
+        assertThat(result).isEqualTo("id=$idWithoutArg, quantity=$quantity")
+    }
+
+    @Test
+    fun toString_createdWithPluralResAndTwoArgs_resultIsCorrect() {
+        val result = TextRef.pluralsRes(idWithTwoArgs, quantity, intArg, stringArg).toString()
+
+        assertThat(result).isEqualTo("id=$idWithTwoArgs, quantity=$quantity, args=[$intArg, $stringArg]")
+    }
+
+    @Test
     fun toString_createdWithString_resultIsCorrect() {
-        val result = TextRef(stringWithoutArg).toString()
+        val result = TextRef.string(stringWithoutArg).toString()
 
         assertThat(result).isEqualTo("string=$stringWithoutArg")
     }
 
     @Test
     fun toString_createdWithStringAndTwoArgs_resultIsCorrect() {
-        val result = TextRef(stringWithTwoArgs, intArg, stringArg).toString()
+        val result = TextRef.string(stringWithTwoArgs, intArg, stringArg).toString()
 
         assertThat(result).isEqualTo("string=$stringWithTwoArgs, args=[$intArg, $stringArg]")
     }
@@ -161,45 +230,49 @@ class TextRefTest {
 
     @Test
     fun testEquals() {
-        assertThat(TextRef(5))
-            .isEqualTo(TextRef(5))
-        assertThat(TextRef(6))
-            .isNotEqualTo(TextRef(7))
-        assertThat(TextRef("foobar"))
-            .isEqualTo(TextRef("foobar"))
-        assertThat(TextRef("foobar"))
-            .isNotEqualTo(TextRef("bizbaz"))
-        assertThat(TextRef("foobar"))
-            .isNotEqualTo(TextRef(7))
-        assertThat(TextRef("foobar", 1))
-            .isEqualTo(TextRef("foobar", 1))
-        assertThat(TextRef("foobar", 1))
-            .isNotEqualTo(TextRef("bizbaz", 2))
-        assertThat(TextRef(5, 1))
-            .isEqualTo(TextRef(5, 1))
-        assertThat(TextRef(5, 1))
-            .isNotEqualTo(TextRef(5, 2))
+        assertThat(TextRef.stringRes(5))
+            .isEqualTo(TextRef.stringRes(5))
+        assertThat(TextRef.stringRes(6))
+            .isNotEqualTo(TextRef.stringRes(7))
+        assertThat(TextRef.string("foobar"))
+            .isEqualTo(TextRef.string("foobar"))
+        assertThat(TextRef.string("foobar"))
+            .isNotEqualTo(TextRef.string("bizbaz"))
+        assertThat(TextRef.string("foobar"))
+            .isNotEqualTo(TextRef.stringRes(7))
+        assertThat(TextRef.string("foobar", 1))
+            .isEqualTo(TextRef.string("foobar", 1))
+        assertThat(TextRef.string("foobar", 1))
+            .isNotEqualTo(TextRef.string("bizbaz", 2))
+        assertThat(TextRef.stringRes(5, 1))
+            .isEqualTo(TextRef.stringRes(5, 1))
+        assertThat(TextRef.stringRes(5, 1))
+            .isNotEqualTo(TextRef.stringRes(5, 2))
     }
 
     @Test
     fun testHashCode() {
-        assertThat(TextRef(5)
-            .hashCode()).isEqualTo(TextRef(5).hashCode())
-        assertThat(TextRef(6)
-            .hashCode()).isNotEqualTo(TextRef(7).hashCode())
-        assertThat(TextRef("foobar").hashCode())
-            .isEqualTo(TextRef("foobar").hashCode())
-        assertThat(TextRef("foobar").hashCode())
-            .isNotEqualTo(TextRef("bizbaz").hashCode())
-        assertThat(TextRef("foobar").hashCode())
-            .isNotEqualTo(TextRef(7).hashCode())
-        assertThat(TextRef("foobar", 1).hashCode())
-            .isEqualTo(TextRef("foobar", 1).hashCode())
-        assertThat(TextRef("foobar", 1).hashCode())
-            .isNotEqualTo(TextRef("bizbaz", 2).hashCode())
-        assertThat(TextRef(5, 1).hashCode())
-            .isEqualTo(TextRef(5, 1).hashCode())
-        assertThat(TextRef(5, 1).hashCode())
-            .isNotEqualTo(TextRef(5, 2).hashCode())
+        assertThat(
+            TextRef.stringRes(5)
+                .hashCode()
+        ).isEqualTo(TextRef.stringRes(5).hashCode())
+        assertThat(
+            TextRef.stringRes(6)
+                .hashCode()
+        ).isNotEqualTo(TextRef.stringRes(7).hashCode())
+        assertThat(TextRef.string("foobar").hashCode())
+            .isEqualTo(TextRef.string("foobar").hashCode())
+        assertThat(TextRef.string("foobar").hashCode())
+            .isNotEqualTo(TextRef.string("bizbaz").hashCode())
+        assertThat(TextRef.string("foobar").hashCode())
+            .isNotEqualTo(TextRef.stringRes(7).hashCode())
+        assertThat(TextRef.string("foobar", 1).hashCode())
+            .isEqualTo(TextRef.string("foobar", 1).hashCode())
+        assertThat(TextRef.string("foobar", 1).hashCode())
+            .isNotEqualTo(TextRef.string("bizbaz", 2).hashCode())
+        assertThat(TextRef.stringRes(5, 1).hashCode())
+            .isEqualTo(TextRef.stringRes(5, 1).hashCode())
+        assertThat(TextRef.stringRes(5, 1).hashCode())
+            .isNotEqualTo(TextRef.stringRes(5, 2).hashCode())
     }
 }


### PR DESCRIPTION
Constructors have been deprecated in favor of factory functions.

Adding a constructor for plurals caused problems because it can easily be confused with the constructor for string IDs (is `TextRef(1, 2)` a plural string or or a string resource with 1 argument?