### PR TITLE
Compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,9 +127,11 @@ dependencies {
 
 **Step 2.** Add the changes to the top of [CHANGELOG.md](CHANGELOG.md)
 
-**Step 3.** Commit and push
+**Step 3.** Update the version in [`lib/build.gradle.kts`](lib/build.gradle.kts)
 
-**Step 4.** Create a git tag with the version of the CHANGELOG and push
+**Step 4.** Commit and push
+
+**Step 5.** Create a git tag with the version of the CHANGELOG and push
 
 ```
 git tag x.y.z

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,8 @@
 [libraries]
-android-annotation = "androidx.annotation:annotation:1.6.0"
+android-annotation = "androidx.annotation:annotation:1.5.0"
+android-compose-runtime = "androidx.compose.runtime:runtime:1.4.2"
+android-compose-ui = "androidx.compose.ui:ui:1.4.2"
+tools-android-compose = "androidx.compose.compiler:compiler:1.4.6"
 test-junit = "junit:junit:4.13.2"
 test-assertj = "org.assertj:assertj-core:3.24.2"
 test-mockito = "org.mockito:mockito-core:5.3.1"
@@ -8,6 +11,9 @@ androidTest-runner = "androidx.test:runner:1.5.2"
 androidTest-extJunit = "androidx.test.ext:junit:1.1.5"
 androidTest-assertParcelable = "com.artemzin.assert-parcelable:assert-parcelable:1.0.1"
 
+[bundles]
+android-compose = ["android-compose-runtime", "android-compose-ui"]
+
 [plugins]
 androidGradlePlugin = "com.android.library:8.0.0"
-kotlin = "org.jetbrains.kotlin.android:1.8.21"
+kotlin = "org.jetbrains.kotlin.android:1.8.20"

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+    - openjdk17

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.kotlinExtension
 plugins {
     alias(libs.plugins.androidGradlePlugin)
     alias(libs.plugins.kotlin)
+    `maven-publish`
 }
 
 kotlinExtension.jvmToolchain(19)
@@ -38,4 +39,25 @@ dependencies {
     androidTestImplementation(libs.androidTest.runner)
     androidTestImplementation(libs.androidTest.extJunit)
     androidTestImplementation(libs.androidTest.assertParcelable)
+}
+
+android.publishing {
+    singleVariant("release") {
+        withSourcesJar()
+        withJavadocJar()
+    }
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = "com.github.ioki-mobility"
+            artifactId = "TextRef"
+            version = "1.3.1"
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -9,13 +9,13 @@ kotlinExtension.jvmToolchain(19)
 
 android {
     namespace = "com.ioki.textref"
-
-    compileSdk = 30
-
+    compileSdk = 31
     defaultConfig {
         minSdk = 14
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
+    buildFeatures.compose = true
+    composeOptions.kotlinCompilerExtensionVersion = libs.tools.android.compose.get().version
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
@@ -26,6 +26,7 @@ android {
 dependencies {
     // Implementation
     compileOnly(libs.android.annotation)
+    implementation(libs.bundles.android.compose)
 
     // Test
     testImplementation(libs.test.junit)

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,9 +10,9 @@ kotlinExtension.jvmToolchain(19)
 
 android {
     namespace = "com.ioki.textref"
-    compileSdk = 31
+    compileSdk = 33
     defaultConfig {
-        minSdk = 14
+        minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
     buildFeatures.compose = true

--- a/lib/src/main/java/com/ioki/textref/compose/TextRef.kt
+++ b/lib/src/main/java/com/ioki/textref/compose/TextRef.kt
@@ -1,0 +1,11 @@
+package com.ioki.textref.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import com.ioki.textref.TextRef
+
+@Composable
+fun textRef(textRef: TextRef): String = textRef.resolve(LocalContext.current)
+
+@Composable
+fun textRefOrNull(textRef: TextRef?): String? = textRef?.resolve(LocalContext.current)


### PR DESCRIPTION
Fixes #29 

Works just out of the box.
If a consumer doesn't use compose, he can't use the `textRef` functions.
But the library still works.