### PR TITLE
Use spdx identifier for license name

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -48,7 +48,7 @@ publishing {
                 url.set("https://github.com/ioki-mobility/TextRef")
                 licenses {
                     license {
-                        name.set("MIT License")
+                        name.set("MIT")
                         url.set("https://github.com/ioki-mobility/TextRef/blob/main/LICENSE.md")
                     }
                 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -57,7 +57,7 @@ publishing {
                 url.set("https://github.com/ioki-mobility/TextRef")
                 licenses {
                     license {
-                        name.set("MIT License")
+                        name.set("MIT")
                         url.set("https://github.com/ioki-mobility/TextRef/blob/main/LICENSE.md")
                     }
                 }


### PR DESCRIPTION
Use the official [SPDX identifier](https://spdx.org/licenses/) which is just `MIT` 🙃 