### PR TITLE
Fix license url

### DIFF
--- a/compose/build.gradle.kts
+++ b/compose/build.gradle.kts
@@ -49,7 +49,7 @@ publishing {
                 licenses {
                     license {
                         name.set("MIT")
-                        url.set("https://github.com/ioki-mobility/TextRef/blob/main/LICENSE.md")
+                        url.set("https://opensource.org/licenses/MIT")
                     }
                 }
                 organization {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -58,7 +58,7 @@ publishing {
                 licenses {
                     license {
                         name.set("MIT")
-                        url.set("https://github.com/ioki-mobility/TextRef/blob/main/LICENSE.md")
+                        url.set("https://opensource.org/licenses/MIT")
                     }
                 }
                 organization {


### PR DESCRIPTION
The license URL should point to the "original license" defined by the [spdx license specification](https://spdx.org/licenses/).

