### PR TITLE
Bump Gradle Wrapper from 9.7.0 to 9.7.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionSha256Sum=84fbba45c7f4c64abc77460e1c00f541e9f960e3c7ed2538f1ede19eacd873ae
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
+distributionSha256Sum=acd53f1edaf02f1a8ff99879f8a34b302661a057d9b063ae9e35b552f804d20a
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Bump Gradle Wrapper from 9.7.0 to 9.7.1.

Release notes of Gradle 9.7.1 can be found here:
https://docs.gradle.org/9.7.1/release-notes.html